### PR TITLE
Update browser field definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ It is up to the resolver of the runtime, tool or environment to decide which tar
 The initial proposed list of targets is the following:
 
 * _main_: The default fallback target for any environment.
-* _browser_: A browser environment, defined by the presence of the `document` global.
+* _browser_: A web browser environment, that is not also a Node.js environment (eg Electron does not follow the browser field).
 * _electron_: Electron, as defined by the runtime of the Electron project, or any fork of it.
 * _react-native_: React Native, as defined by the runtime of the React Native project, or any fork of it.
 * _development_: Any environment which can be considered to be running in development mode.


### PR DESCRIPTION
This updates the definition of the browser field to mean a browser environment that is not a Node.js environment.

This is in order to ensure Electron compatibility, which does not follow the browser field (https://github.com/electron/electron/issues/1574).