### PR TITLE
Introduce not found target, provide typing definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ In addition to string targets it is also possible to define a not found target w
 {
   "browser": null,
   "exports": {
-    "./": { browser: null }
+    "./": { "browser": null }
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -128,3 +128,40 @@ In addition, targets can compose through nesting:
 ```
 
 allowing splitting of `pkg/features/x.js` resolution between browser production and browser development environments.
+
+#### Not Found Target
+
+In addition to string targets it is also possible to define a not found target which indicates that there should be no mapping for the given module:
+
+```js
+{
+  "browser": false,
+  "exports": {
+    "./": { browser: false }
+  }
+}
+```
+
+The above implies that a _Module Not Found_ error should be thrown when attempting to resolve the given resolutions for the browser.
+
+### Full Type Definitions
+
+Combining all of the above, the proposal types can be defined as (in TypeScript):
+
+```typescript
+type TargetValue = string | false | TargetMap | TargetArray;
+interface TargetMap {
+  [conditional: string]: TargetValue;
+};
+interface TargetArray extends Array<TargetValue> {};
+```
+
+where the individual targets are defined as type `TargetValue`, and the _exports_ field is defined as a map of target values:
+
+```typescript
+type PackageExports = string | false | {
+  [key: string]: TargetValue
+};
+```
+
+

--- a/README.md
+++ b/README.md
@@ -135,9 +135,9 @@ In addition to string targets it is also possible to define a not found target w
 
 ```js
 {
-  "browser": false,
+  "browser": null,
   "exports": {
-    "./": { browser: false }
+    "./": { browser: null }
   }
 }
 ```
@@ -149,7 +149,7 @@ The above implies that a _Module Not Found_ error should be thrown when attempti
 Combining all of the above, the proposal types can be defined as (in TypeScript):
 
 ```typescript
-type TargetValue = string | false | TargetMap | TargetArray;
+type TargetValue = string | null | TargetMap | TargetArray;
 interface TargetMap {
   [conditional: string]: TargetValue;
 };
@@ -163,5 +163,6 @@ type PackageExports = string | false | {
   [key: string]: TargetValue
 };
 ```
+
 
 


### PR DESCRIPTION
This PR introduces `null` as meaning the _not found_ target.

This allows a package to provide eg `"browser": null` indicating that an attempt to resolve the package for the browser should fail.

This is also useful in fallbacks as it provides an explicit error instead of the usual fallback behaviour of moving on to the next item.

We could use a special string value instead of `null`, but it seems better to avoid collisions entirely using a different type.

In the process I've also added the TypeScript definitions for the fields implied by the proposal to ensure the definitions are completely clear.